### PR TITLE
Fix Multibase Bug

### DIFF
--- a/src/multibase/multibase.c
+++ b/src/multibase/multibase.c
@@ -62,7 +62,7 @@ int multibase_encode(const char base, const unsigned char *incoming,
     /*!
       * @note: memcpy can't handle overlapping bytes so use memmove
     */
-    memmove(&results[1], results, *results_length);
+    memmove(results + 1, results, *results_length);
     // memcpy(&results[1], results, *results_length);
     results[0] = base;
     *results_length += 1;

--- a/src/multibase/multibase.c
+++ b/src/multibase/multibase.c
@@ -25,7 +25,7 @@ int multibase_encode(const char base, const unsigned char *incoming,
                      size_t results_max_length, size_t *results_length) {
     *results_length = results_max_length;
     int retVal = 0;
-
+    
     switch (base) {
         case (MULTIBASE_BASE16):
             retVal = libp2p_encoding_base16_encode(incoming, incoming_length,
@@ -58,8 +58,12 @@ int multibase_encode(const char base, const unsigned char *incoming,
                               // just in case.
         return 0;             // buffer isn't big enough
     }
-
-    memcpy(&results[1], results, *results_length);
+    
+    /*!
+      * @note: memcpy can't handle overlapping bytes so use memmove
+    */
+    memmove(&results[1], results, *results_length);
+    // memcpy(&results[1], results, *results_length);
     results[0] = base;
     *results_length += 1;
 


### PR DESCRIPTION
There was a multibase bug causing UB via `memcpy` and using overlapping data. This switches from `memcpy` to `memmove`. Closes https://github.com/RTradeLtd/libcp2p/issues/23