### PR TITLE
Fix Usage Of Calloc

### DIFF
--- a/src/crypto/aes.c
+++ b/src/crypto/aes.c
@@ -56,7 +56,7 @@ int libp2p_crypto_aes_encrypt(char *key, char *iv, char *input, size_t input_siz
     if (new_size % 16 != 0) {
         new_size += new_size % 16;
     }
-    char *padded_input = calloc(sizeof(char), new_size);
+    char *padded_input = calloc(1, new_size);
     if (padded_input == NULL) {
         return 0;
     }

--- a/src/crypto/crypto_test.c
+++ b/src/crypto/crypto_test.c
@@ -102,7 +102,7 @@ void test_libp2p_crypto_hashing_sha1_hmac(void **state) {
         strlen((char *)msg)
     );
     assert(rc == 1);
-    uint8_t *output = calloc(sizeof(uint8_t), sizeof(uint8_t) * 32 + 1);
+    uint8_t *output = calloc(1, sizeof(uint8_t) * 32 + 1);
     rc = libp2p_crypto_hashing_sha1_finish(
         &ctx,
         output
@@ -110,7 +110,7 @@ void test_libp2p_crypto_hashing_sha1_hmac(void **state) {
     assert(strlen((char *)output) == 20);
     assert(rc == 1);
 
-    uint8_t *base64_encoded = calloc(sizeof(uint8_t), sizeof(uint8_t) * 64 + 1);
+    uint8_t *base64_encoded = calloc(1, sizeof(uint8_t) * 64 + 1);
     size_t len;
     rc = libp2p_encoding_base64_encode(
         output,
@@ -127,7 +127,7 @@ void test_libp2p_crypto_hashing_sha1_hmac(void **state) {
         ) == 0
     );
 
-    uint8_t *base64_decoded = calloc(sizeof(uint8_t), sizeof(uint8_t) * 32 + 1);
+    uint8_t *base64_decoded = calloc(1, sizeof(uint8_t) * 32 + 1);
     rc = libp2p_encoding_base64_decode(
         base64_encoded,
         strlen((char *)base64_encoded),
@@ -161,7 +161,7 @@ void test_libp2p_crypto_hashing_sha256_hmac(void **state) {
         strlen((char *)msg)
     );
     assert(rc == 1);
-    uint8_t *output = calloc(sizeof(uint8_t), sizeof(uint8_t) * 32 + 1);
+    uint8_t *output = calloc(1, sizeof(uint8_t) * 32 + 1);
     rc = libp2p_crypto_hashing_sha256_finish(
         &ctx,
         output
@@ -169,7 +169,7 @@ void test_libp2p_crypto_hashing_sha256_hmac(void **state) {
     assert(strlen((char *)output) == 32);
     assert(rc == 1);
 
-    uint8_t *base64_encoded = calloc(sizeof(uint8_t), sizeof(uint8_t) * 64 + 1);
+    uint8_t *base64_encoded = calloc(1, sizeof(uint8_t) * 64 + 1);
     size_t len;
     rc = libp2p_encoding_base64_encode(
         output,
@@ -186,7 +186,7 @@ void test_libp2p_crypto_hashing_sha256_hmac(void **state) {
         ) == 0
     );
 
-    uint8_t *base64_decoded = calloc(sizeof(uint8_t), sizeof(uint8_t) * 32 + 1);
+    uint8_t *base64_decoded = calloc(1, sizeof(uint8_t) * 32 + 1);
     rc = libp2p_encoding_base64_decode(
         base64_encoded,
         strlen((char *)base64_encoded),
@@ -211,14 +211,14 @@ void test_libp2p_crypto_hashing_sha256_hmac(void **state) {
 
 void test_libp2p_crypto_hashing_sha512(void **state) {
     uint8_t input[] = "some input text";
-    uint8_t *output = calloc(sizeof(uint8_t), sizeof(uint8_t) * 256);
+    uint8_t *output = calloc(1, sizeof(uint8_t) * 256);
     int rc = libp2p_crypto_hashing_sha512(
         input, strlen((char *)input),
         output
     );
     assert(rc == 64);
     assert(strlen((char *)output) == 64);
-    uint8_t *base64_output = calloc(sizeof(unsigned char), sizeof(unsigned char) * 512);
+    uint8_t *base64_output = calloc(1, sizeof(unsigned char) * 512);
     size_t len;
     rc = libp2p_encoding_base64_encode(
         output,
@@ -234,7 +234,7 @@ void test_libp2p_crypto_hashing_sha512(void **state) {
             "/3SZKSbv6ZRZfi/hTh3q3nSyr4XrexgicQqQF56fsG5M1YFSc2OdbXcsmVxFdFSZTKz9sOKJt2Z7YfYlSlIKGg=="
         ) == 0
     );
-    uint8_t *base64_decode = calloc(sizeof(unsigned char), sizeof(unsigned char) * 512);
+    uint8_t *base64_decode = calloc(1, sizeof(unsigned char) * 512);
     rc = libp2p_encoding_base64_decode(
         base64_output,
         strlen((char *)base64_output),
@@ -263,7 +263,7 @@ void test_libp2p_crypto_hashing_sha512(void **state) {
 
 void test_libp2p_crypto_hashing_sha256(void **state) {
     uint8_t input[] = "some input text";
-    uint8_t *output = calloc(sizeof(uint8_t), sizeof(uint8_t) * 256);
+    uint8_t *output = calloc(1, sizeof(uint8_t) * 256);
     // unsigned char *input = (unsigned char *)"some input text";
     // unsigned char *output = malloc(sizeof(unsigned char *) * 256 + 1);
     int rc = libp2p_crypto_hashing_sha256(
@@ -272,7 +272,7 @@ void test_libp2p_crypto_hashing_sha256(void **state) {
     );
     assert(rc);
     assert(strlen((char *)output) == 32);
-    uint8_t *base64_output = calloc(sizeof(uint8_t), sizeof(uint8_t) * 512);
+    uint8_t *base64_output = calloc(1, sizeof(uint8_t) * 512);
     size_t len;
 
     rc = libp2p_encoding_base64_encode(
@@ -285,7 +285,7 @@ void test_libp2p_crypto_hashing_sha256(void **state) {
     assert(rc == 1);
     assert(strcmp((char *)base64_output, "ELK1zDN90JmPWKbSaORqMQ1B17AJHbDNx5DrcINHY28=") == 0);
 
-    uint8_t *decode_output = calloc(sizeof(uint8_t), sizeof(uint8_t) * 512);
+    uint8_t *decode_output = calloc(1, sizeof(uint8_t) * 512);
     rc = libp2p_encoding_base64_decode(
         base64_output,
         strlen((char *)base64_output),
@@ -314,7 +314,7 @@ void test_libp2p_crypto_hashing_sha256(void **state) {
 
 void test_libp2p_crypto_cbor_encode_pub_key(void **state) {
     {
-        unsigned char *output = calloc(sizeof(unsigned char), 1024);
+        unsigned char *output = calloc(1, 1024);
 
         int rc = libp2p_crypto_ecdsa_keypair_generation(output, MBEDTLS_ECP_DP_SECP256R1);    
         assert(rc == 1);
@@ -336,7 +336,7 @@ void test_libp2p_crypto_cbor_encode_pub_key(void **state) {
         );
         assert(out != NULL);
         
-        unsigned char *encoded = calloc(sizeof(unsigned char), 2048);
+        unsigned char *encoded = calloc(1, 2048);
         size_t encoded_size;
         rc = libp2p_encoding_base64_encode(
             out->data,
@@ -372,7 +372,7 @@ void test_libp2p_crypto_cbor_encode_pub_key(void **state) {
         libp2p_crypto_ecdsa_free(pk);
     }
     public_key_t *test_key = libp2p_crypto_public_key_new();
-    test_key->data = calloc(sizeof(unsigned char), 7);
+    test_key->data = calloc(1, 7);
     test_key->data_size = 7;
     test_key->data[0] = '1';
     test_key->data[1] = '2'; 
@@ -385,7 +385,7 @@ void test_libp2p_crypto_cbor_encode_pub_key(void **state) {
 
     cbor_encoded_data_t *out = libp2p_crypto_public_key_cbor_encode(test_key);
     assert(out != NULL);
-    unsigned char *encoded = calloc(sizeof(unsigned char), 2048);
+    unsigned char *encoded = calloc(1, 2048);
     size_t encoded_size;
     int rc = libp2p_encoding_base64_encode(
         out->data,

--- a/src/crypto/ecdsa.c
+++ b/src/crypto/ecdsa.c
@@ -69,7 +69,7 @@ unsigned char *libp2p_crypto_ecdsa_keypair_peerid(ecdsa_private_key_t *pk) {
     if (public_key == NULL) {
         return NULL;
     }
-    unsigned char *public_key_hash = calloc(sizeof(unsigned char), 64);
+    unsigned char *public_key_hash = calloc(1, 64);
     if (public_key_hash == NULL) {
         return NULL;
     }
@@ -93,7 +93,7 @@ unsigned char *libp2p_crypto_ecdsa_keypair_peerid(ecdsa_private_key_t *pk) {
     }
 
     size_t tpid_size = strlen((char *)temp_peer_id);
-    unsigned char *peer_id = calloc(sizeof(unsigned char), tpid_size + 2);
+    unsigned char *peer_id = calloc(1, tpid_size + 2);
     if (peer_id == NULL) {
         free(public_key);
         free(public_key_hash);

--- a/src/crypto/key.c
+++ b/src/crypto/key.c
@@ -194,11 +194,11 @@ public_key_t *libp2p_crypto_public_key_cbor_decode(cbor_encoded_data_t *data) {
         return NULL;
     }
 
-    public_key_t *pk = calloc(sizeof(public_key_t), sizeof(public_key_t));
+    public_key_t *pk = calloc(1, sizeof(public_key_t));
     if (pk == NULL) {
         return NULL;
     }
-    pk->data = calloc(sizeof(unsigned char), data_len);
+    pk->data = calloc(1, data_len);
     if (pk->data == NULL) {
         free(pk);
         return NULL;

--- a/src/encoding/cbor.c
+++ b/src/encoding/cbor.c
@@ -26,8 +26,7 @@ void free_cbor_encoded_data(cbor_encoded_data_t *in) {
  * @return Failure: NULL pointer
  */
 cbor_encoded_data_t *new_cbor_encoded_data(uint8_t *data, size_t len) {
-    cbor_encoded_data_t *out =
-        calloc(sizeof(cbor_encoded_data_t), sizeof(cbor_encoded_data_t));
+    cbor_encoded_data_t *out = calloc(1, sizeof(cbor_encoded_data_t));
     if (out == NULL) {
         return NULL;
     }

--- a/src/multiaddr/multiaddr.c
+++ b/src/multiaddr/multiaddr.c
@@ -28,7 +28,7 @@ struct multi_address *multi_address_new() {
         out->bsize = 0;
         out->bytes = NULL;
         /*! @todo figure out a better way of estimating size */
-        out->string = calloc(sizeof(char), 800);
+        out->string = calloc(1, 800);
     }
     return out;
 }

--- a/src/multibase/multibase.c
+++ b/src/multibase/multibase.c
@@ -105,7 +105,7 @@ int multibase_decode(const unsigned char *incoming, size_t incoming_length,
     const char base = incoming[0];
 
     // parse the actual encoded data fro mthe base identifier
-    unsigned char *rest = calloc(sizeof(unsigned char), incoming_length);
+    unsigned char *rest = calloc(1, incoming_length);
     if (rest == NULL) {
         return 0;
     }

--- a/src/multibase/multibase_test.c
+++ b/src/multibase/multibase_test.c
@@ -19,7 +19,7 @@ void test_multibase_encode_decode_base16(void **state) {
     );
     assert(esize > 0);
 
-    unsigned char *output = calloc(sizeof(unsigned char), esize);
+    unsigned char *output = calloc(1, esize);
     size_t len;
     int rc = multibase_encode(
         MULTIBASE_BASE16, 
@@ -40,7 +40,7 @@ void test_multibase_encode_decode_base16(void **state) {
     int dsize = multibase_decode_size(MULTIBASE_BASE16, output, len);
     assert(dsize > 0);
 
-    unsigned char *decoded_output = calloc(sizeof(unsigned char), dsize);
+    unsigned char *decoded_output = calloc(1, dsize);
     size_t written;
     rc = multibase_decode(output, len, decoded_output, dsize, &written);
     assert(rc == 1);
@@ -61,7 +61,7 @@ void test_multibase_encode_decode_base32(void **state) {
     int esize = multibase_encode_size(MULTIBASE_BASE32, input, 12);
     assert(esize > 0);
     
-    unsigned char *output = calloc(sizeof(unsigned char), esize);
+    unsigned char *output = calloc(1, esize);
     size_t len;
     int rc = multibase_encode(
         MULTIBASE_BASE32,
@@ -83,7 +83,7 @@ void test_multibase_encode_decode_base32(void **state) {
     int dsize = multibase_decode_size(MULTIBASE_BASE16, output, len);
     assert(dsize > 0);
 
-    unsigned char *decoded_output = calloc(sizeof(unsigned char), dsize);
+    unsigned char *decoded_output = calloc(1, dsize);
     size_t res;
     rc = multibase_decode(
         output,
@@ -110,7 +110,7 @@ void test_multibase_encode_decode_base64(void **state) {
     int esize = multibase_encode_size(MULTIBASE_BASE64, input, 12);
     assert(esize > 0);
 
-    unsigned char *output = calloc(sizeof(unsigned char), esize);
+    unsigned char *output = calloc(1, esize);
     size_t len;
     int rc = multibase_encode(
         MULTIBASE_BASE64,
@@ -132,7 +132,7 @@ void test_multibase_encode_decode_base64(void **state) {
     int dsize = multibase_encode_size(MULTIBASE_BASE64, output, len);
     assert(dsize > 0);
 
-    unsigned char *decoded_output = calloc(sizeof(unsigned char), dsize);
+    unsigned char *decoded_output = calloc(1, dsize);
     size_t res;
     rc = multibase_decode(
         output,

--- a/src/multicodec/multicodec.c
+++ b/src/multicodec/multicodec.c
@@ -504,8 +504,7 @@ multicodec_encoded_t *multicodec_encode(char *codec, char *inData,
         return NULL;
     }
 
-    multicodec_encoded_t *encoded =
-        calloc(sizeof(multicodec_encoded_t), sizeof(multicodec_encoded_t));
+    multicodec_encoded_t *encoded = calloc(1, sizeof(multicodec_encoded_t));
     if (encoded == NULL) {
         return NULL;
     }

--- a/src/multicodec/multicodec_test.c
+++ b/src/multicodec/multicodec_test.c
@@ -62,7 +62,7 @@ void test_multicodec_encode_decode(void **state) {
             ) == 0
         );
 
-        char *decoded_out = calloc(sizeof(char), 12); 
+        char *decoded_out = calloc(1, 12); 
         int rc = multicodec_decode(
             encoded,
             decoded_out,

--- a/src/network/socket.c
+++ b/src/network/socket.c
@@ -135,7 +135,7 @@ char *get_name_info(sock_addr *client_address) {
                 0,                    // length of the second buffer
                 NI_NUMERICHOST        // want to see hostnmae as an ip address
     );
-    char *addr = calloc(sizeof(address_info), sizeof(address_info));
+    char *addr = calloc(1, sizeof(address_info));
     if (addr == NULL) {
         return NULL;
     }

--- a/src/network/socket_client.c
+++ b/src/network/socket_client.c
@@ -88,7 +88,7 @@ socket_client_t *new_socket_client(thread_logger *thl, multi_addr_t *addr) {
     }
 
     socket_client_t *sock_client =
-        calloc(sizeof(sock_client), sizeof(sock_client) + sizeof(peer_address));
+        calloc(1, sizeof(sock_client) + sizeof(peer_address));
     if (sock_client == NULL) {
         thl->log(thl, 0, "failed to calloc socket_client_t", LOG_LEVELS_ERROR);
         return NULL;

--- a/src/network/socket_server.c
+++ b/src/network/socket_server.c
@@ -194,8 +194,7 @@ socket_server_t *new_socket_server(thread_logger *thl,
         }
     }
 
-    socket_server_t *server =
-        calloc(sizeof(socket_server_t), sizeof(socket_server_t));
+    socket_server_t *server = calloc(1, sizeof(socket_server_t));
     if (server == NULL) {
         thl->log(thl, 0, "failed to calloc socket server", LOG_LEVELS_ERROR);
         goto EXIT;
@@ -315,8 +314,8 @@ void start_socket_server(socket_server_t *srv) {
                         continue;
                     }
 
-                    conn_handle_data_t *chdata = calloc(sizeof(conn_handle_data_t),
-                                                        sizeof(conn_handle_data_t));
+                    conn_handle_data_t *chdata =
+                        calloc(1, sizeof(conn_handle_data_t));
                     if (chdata == NULL) {
                         close(conn->socket_number);
                         free(conn->address);
@@ -333,8 +332,7 @@ void start_socket_server(socket_server_t *srv) {
                 // if it is a udp socket, handle it with the udp worker func
                 if (FD_ISSET(i, &srv->udp_socket_set)) {
 
-                    client_conn_t *conn =
-                        calloc(sizeof(client_conn_t), sizeof(client_conn_t));
+                    client_conn_t *conn = calloc(1, sizeof(client_conn_t));
                     if (conn == NULL) {
                         srv->thl->log(srv->thl, 0, "failed to calloc client_t",
                                       LOG_LEVELS_ERROR);
@@ -343,8 +341,8 @@ void start_socket_server(socket_server_t *srv) {
                     }
                     conn->socket_number = i;
 
-                    conn_handle_data_t *chdata = calloc(sizeof(conn_handle_data_t),
-                                                        sizeof(conn_handle_data_t));
+                    conn_handle_data_t *chdata =
+                        calloc(1, sizeof(conn_handle_data_t));
                     if (chdata == NULL) {
                         free(conn);
                         srv->thl->log(srv->thl, 0, "failed to calloc client_t",
@@ -392,7 +390,7 @@ client_conn_t *accept_client_conn(socket_server_t *srv, int socket_num) {
     if (client_socket_num < 0) {
         return NULL;
     }
-    client_conn_t *connection = calloc(sizeof(client_conn_t), sizeof(client_conn_t));
+    client_conn_t *connection = calloc(1, sizeof(client_conn_t));
     if (connection == NULL) {
         return NULL;
     }
@@ -426,12 +424,11 @@ void free_socket_server_config(socket_server_config_t *config) {
  * @return Failure: NULL pointer
  */
 socket_server_config_t *new_socket_server_config(int num_addrs) {
-    socket_server_config_t *config =
-        calloc(sizeof(socket_server_config_t), sizeof(socket_server_config_t));
+    socket_server_config_t *config = calloc(1, sizeof(socket_server_config_t));
     if (config == NULL) {
         return NULL;
     }
-    config->addrs = calloc(sizeof(multi_addr_t), sizeof(multi_addr_t) * 2);
+    config->addrs = calloc(1, sizeof(multi_addr_t) * 2);
     config->num_addrs = num_addrs;
     return config;
 }

--- a/src/utils/colors.c
+++ b/src/utils/colors.c
@@ -58,7 +58,7 @@ int write_colored(COLORS color, int file_descriptor, char *message) {
     }
     // 2 for \n
     char *write_message =
-        calloc(sizeof(char), strlen(pcolor) + strlen(reset) + strlen(message) + 2);
+        calloc(1, strlen(pcolor) + strlen(reset) + strlen(message) + 2);
     if (write_message == NULL) {
         printf("failed to calloc write_message\n");
         return -1;

--- a/src/utils/logger.c
+++ b/src/utils/logger.c
@@ -76,7 +76,7 @@ file_logger *new_file_logger(char *output_file, bool with_debug) {
 
 int write_file_log(int file_descriptor, char *message) {
     // 2 for \n
-    char *msg = calloc(sizeof(char), strlen(message) + 2);
+    char *msg = calloc(1, strlen(message) + 2);
     if (msg == NULL) {
         printf("failed to calloc msg\n");
         return -1;
@@ -122,7 +122,7 @@ void log_func(thread_logger *thl, int file_descriptor, char *message,
         // dont printf log as get_time_str does that
         return;
     }
-    char *date_msg = calloc(sizeof(char), strlen(time_str) + strlen(message) + 2);
+    char *date_msg = calloc(1, strlen(time_str) + strlen(message) + 2);
     if (date_msg == NULL) {
         printf("failed to calloc date_msg\n");
         return;
@@ -150,8 +150,7 @@ void log_func(thread_logger *thl, int file_descriptor, char *message,
 void info_log(thread_logger *thl, int file_descriptor, char *message) {
     thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
-    char *msg =
-        calloc(sizeof(char), strlen(message) + strlen("[info - ") + (size_t)2);
+    char *msg = calloc(1, strlen(message) + strlen("[info - ") + (size_t)2);
     if (msg == NULL) {
         printf("failed to calloc info_log msg");
         return;
@@ -169,8 +168,7 @@ void info_log(thread_logger *thl, int file_descriptor, char *message) {
 void warn_log(thread_logger *thl, int file_descriptor, char *message) {
     thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
-    char *msg =
-        calloc(sizeof(char), strlen(message) + strlen("[warn - ") + (size_t)2);
+    char *msg = calloc(1, strlen(message) + strlen("[warn - ") + (size_t)2);
     if (msg == NULL) {
         printf("failed to calloc warn_log msg");
         return;
@@ -192,8 +190,7 @@ void warn_log(thread_logger *thl, int file_descriptor, char *message) {
 void error_log(thread_logger *thl, int file_descriptor, char *message) {
     thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
-    char *msg =
-        calloc(sizeof(char), strlen(message) + strlen("[error - ") + (size_t)2);
+    char *msg = calloc(1, strlen(message) + strlen("[error - ") + (size_t)2);
     if (msg == NULL) {
         printf("failed to calloc error_log msg");
         return;
@@ -216,8 +213,7 @@ void debug_log(thread_logger *thl, int file_descriptor, char *message) {
 
     thl->lock(&thl->mutex);
     // 2 = 1 for null terminator, 1 for space after ]
-    char *msg =
-        calloc(sizeof(char), strlen(message) + strlen("[debug - ") + (size_t)2);
+    char *msg = calloc(1, strlen(message) + strlen("[debug - ") + (size_t)2);
     if (msg == NULL) {
         printf("failed to calloc debug_log msg");
         return;
@@ -246,7 +242,7 @@ char *get_time_string() {
     char date[75];
     strftime(date, sizeof date, "%b %d %r", localtime(&(time_t){time(NULL)}));
     // 4 for [ ] and 1 for \0
-    char *msg = calloc(sizeof(char), sizeof(date) + 2);
+    char *msg = calloc(1, sizeof(date) + 2);
     if (msg == NULL) {
         printf("failed to calloc get_time_string\n");
         return NULL;


### PR DESCRIPTION
## :construction_worker: Purpose

There was incorrect usage of `calloc`, resulting in a lot more memory being allocated. This change reduces the memory allocated for the network test from `269,369 bytes` to `20,639 bytes`

## :rocket: Changes

Use `calloc(1, size_of_data)` insted of `calloc(size_of_data, size_of_data)`


## :warning: Breaking Changes


None
