### PR TITLE
cmake: fix cli build

### DIFF
--- a/cmake/libraries/cli.cmake
+++ b/cmake/libraries/cli.cmake
@@ -1,7 +1,16 @@
-add_executable(cli ${PROJECT_SOURCE_DIR}/src/cli/main.c ${PROJECT_SOURCE_DIR}/src/cli/command_line.c ${PROJECT_SOURCE_DIR}/include/cli/command_line.h)
+add_library(libcli
+    SHARED
+        ./include/cli/command_line.h
+        ./src/cli/command_line.c
+)
+
+target_compile_options(libcli PRIVATE ${flags})
+
+add_executable(cli ${PROJECT_SOURCE_DIR}/src/cli/main.c)
 target_compile_options(cli PRIVATE ${flags})
 target_link_libraries(cli libutils)
 target_link_libraries(cli libargtable)
 target_link_libraries(cli m)
 target_link_libraries(cli libmultiaddr)
-target_link_libraries(cli libnetwork)
+target_link_libraries(cli libnetwork) 
+target_link_libraries(cli libcli)


### PR DESCRIPTION
## :construction_worker: Purpose

Fixes linking issues reported during compilation

```
[ 97%] Linking C executable cli
/usr/bin/ld: CMakeFiles/cli.dir/src/cli/command_line.c.o:(.bss+0x0): multiple definition of `help'; CMakeFiles/cli.dir/src/cli/main.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/cli.dir/src/cli/command_line.c.o:(.bss+0x8): multiple definition of `version'; CMakeFiles/cli.dir/src/cli/main.c.o:(.bss+0x8): first defined here
/usr/bin/ld: CMakeFiles/cli.dir/src/cli/command_line.c.o:(.bss+0x10): multiple definition of `command_to_run'; CMakeFiles/cli.dir/src/cli/main.c.o:(.bss+0x10): first defined here
/usr/bin/ld: CMakeFiles/cli.dir/src/cli/command_line.c.o:(.bss+0x18): multiple definition of `file'; CMakeFiles/cli.dir/src/cli/main.c.o:(.bss+0x18): first defined here
/usr/bin/ld: CMakeFiles/cli.dir/src/cli/command_line.c.o:(.bss+0x20): multiple definition of `output'; CMakeFiles/cli.dir/src/cli/main.c.o:(.bss+0x20): first defined here
/usr/bin/ld: CMakeFiles/cli.dir/src/cli/command_line.c.o:(.bss+0x28): multiple definition of `end'; CMakeFiles/cli.dir/src/cli/main.c.o:(.bss+0x28): first defined here
collect2: error: ld returned 1 exit status
```

## :rocket: Changes

Compile command_line as a shared library


## :warning: Breaking Changes

None

